### PR TITLE
Added temp offset to lmt01 driver

### DIFF
--- a/firmware/include/config/raspberry_latte_config.h
+++ b/firmware/include/config/raspberry_latte_config.h
@@ -1,6 +1,6 @@
 /**
- * Length of time after powering on that the boiler and pump remain inactive. Let's transient voltages 
- * settle out before activating the machine.
+ * Length of time after powering on that the boiler and pump remain inactive. 
+ * Let's transient voltages settle out before activating the machine.
  */
 #define AC_SETTLING_TIME_MS 500
 
@@ -35,3 +35,10 @@
 
 #define AUTOBREW_PREINF_END_PRESSURE_MBAR 3000
 #define AUTOBREW_BREW_PRESSURE_MBAR       9000
+
+/**
+ * The temp that the thermometer is reading may not match the water at the group-head.
+ * This constant defines the discrepancy. Compute the value in C and then multiply by 
+ * 16 and round to an integer. 
+*/
+#define BOILER_TEMP_OFFSET_16C 128

--- a/firmware/include/drivers/lmt01.h
+++ b/firmware/include/drivers/lmt01.h
@@ -30,12 +30,13 @@ typedef struct lmt01_s * lmt01;
  * \brief Configures the signal pin attached to a LMT01 temp sensor and starts a PIO 
  * program that counts the sensors pulse train
  * 
- * \param pio_num Either 0 or 1 indicating if PIO #0 or #1 should be used
- * \param dat_pin Pin that the LMT01 is attached to
+ * \param pio_num    Either 0 or 1 indicating if PIO #0 or #1 should be used
+ * \param dat_pin    Pin that the LMT01 is attached to
+ * \param offset_16C A constant offset added to temp readings in 16*C
  * 
  * \returns A new LMT01 object
  */
-lmt01 lmt01_setup(uint8_t pio_num, uint8_t dat_pin);
+lmt01 lmt01_setup(uint8_t pio_num, uint8_t dat_pin, int offset_16C);
 
 /**
  * \brief Returns the current temperature in 16*C. Divide by 16 to convert to C

--- a/firmware/src/machine_logic/espresso_machine.c
+++ b/firmware/src/machine_logic/espresso_machine.c
@@ -418,7 +418,7 @@ int espresso_machine_setup(espresso_machine_viewer * state_viewer){
     scale = nau7802_setup(bus, SCALE_CONVERSION_MG);
 
     // Setup thermometer
-    thermo = lmt01_setup(0, LMT01_DATA_PIN);
+    thermo = lmt01_setup(0, LMT01_DATA_PIN, BOILER_TEMP_OFFSET_16C);
 
     // Setup AC power sensor
     gpio_irq_timestamp_setup(AC_0CROSS_PIN, ZEROCROSS_EVENT_RISING);


### PR DESCRIPTION
Added a configuration field to config.h header that defines the offset. This is passed into the setup function for the boiler's LMT01 sensor driver. Then, whenever the sensor is read, the offset is added internally. 